### PR TITLE
Update ngFor syntax for beta 17

### DIFF
--- a/src/components/ng2-datepicker.ts
+++ b/src/components/ng2-datepicker.ts
@@ -38,12 +38,12 @@ interface CalendarDate {
       </div>
     </div>
     <div class="day-names">
-      <span *ngFor="#dn of dayNames">
+      <span *ngFor="let dn of dayNames">
         <span>{{ dn }}</span>
       </span>
     </div>
     <div class="calendar">
-      <span *ngFor="#d of days; #i = index;">
+      <span *ngFor="let d of days; let i = index">
         <span class="day" [ngClass]="{'disabled': !d.enabled, 'selected': isSelected(d)}" (click)="selectDate($event, d)">
           {{ d.day }}
         </span>


### PR DESCRIPTION
The syntax was changed in [beta 17](https://github.com/angular/angular/commit/0700c8a2527e542c726bcc9c0d724505720f4908), so instead of `#x of y` within expressions you now use `let x of y`.