### PR TITLE
Fix #46 #58 - Missing box-sizing: border-box

### DIFF
--- a/src/components/ng2-datepicker.css
+++ b/src/components/ng2-datepicker.css
@@ -112,7 +112,9 @@
         cursor: pointer;
         border-radius: 50%; }
         .ui-kit-calendar-container .ui-kit-calendar-cal-container .ui-kit-calendar-days span.today {
-          border: 1px solid #fff; }
+          border: 1px solid #fff;
+          box-sizing: border-box;
+        }
         .ui-kit-calendar-container .ui-kit-calendar-cal-container .ui-kit-calendar-days span:hover, .ui-kit-calendar-container .ui-kit-calendar-cal-container .ui-kit-calendar-days span.is-active {
           background: #fff;
           color: #44c8f9; }


### PR DESCRIPTION
This is a fix for #46 and #58.

On the demo app there is the following global rule on app.css : 

```css
*
*:before,
*:after {
  box-sizing: border-box;
}
```

It sets `border-box` the default `box-sizing`. 
Without that rule the today cell gets bigger and create a gap.

@jkuri I let you check and merge this.