### PR TITLE
change publish script to prepublishOnly

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "git+https://github.com/jkuri/ng2-datepicker.git"
   },
   "scripts": {
-    "prepublish": "tsc"
+    "prepublishOnly": "tsc"
   },
   "keywords": [
     "angular",


### PR DESCRIPTION
Don't run prepublish script on installing package.
When you build your angular 2 application with webpack it process html templates correctly only in ts files. But if there is prepublish script js files generates on install so webpack use js files and doesn't process html templates.
http://iamakulov.com/notes/all/npm-4-prepublish/
