### PR TITLE
Added options for clear button and readonly text input

### DIFF
--- a/src/ng2-datepicker/ng2-datepicker.component.html
+++ b/src/ng2-datepicker/ng2-datepicker.component.html
@@ -1,9 +1,12 @@
 <div class="datepicker-container u-is-unselectable">
   <div class="datepicker-input-container">
-    <input type="text" class="datepicker-input" [(ngModel)]="date.formatted">
+    <input [readonly]="options.isReadOnly ? true : null" type="text" class="datepicker-input" [(ngModel)]="date.formatted">
+    <div *ngIf="options.showClear && value.formatted" class="datepicker-input-icon" style="padding-right: 5px;" (click)="clear()">
+      <i class="ion-ios-close-circle"></i>
+    </div>
     <div class="datepicker-input-icon" (click)="toggle()">
       <i class="ion-ios-calendar"></i>
-    </div>
+    </div>    
   </div>
   <div class="datepicker-calendar" *ngIf="opened">
     <div class="datepicker-calendar-top">

--- a/src/ng2-datepicker/ng2-datepicker.component.ts
+++ b/src/ng2-datepicker/ng2-datepicker.component.ts
@@ -38,6 +38,8 @@ export interface IDatePickerOptions {
   initialDate?: Date;
   firstWeekdaySunday?: boolean;
   format?: string;
+  showClear?: boolean;
+  isReadOnly?: boolean;
 }
 
 export class DatePickerOptions {
@@ -49,6 +51,8 @@ export class DatePickerOptions {
   initialDate?: Date;
   firstWeekdaySunday?: boolean;
   format?: string;
+  showClear?: boolean;
+  isReadOnly?: boolean;
 
   constructor(obj?: IDatePickerOptions) {
     this.autoApply = (obj && obj.autoApply === true) ? true : false;
@@ -59,6 +63,8 @@ export class DatePickerOptions {
     this.initialDate = obj && obj.initialDate ? obj.initialDate : null;
     this.firstWeekdaySunday = obj && obj.firstWeekdaySunday ? obj.firstWeekdaySunday : false;
     this.format = obj && obj.format ? obj.format : 'YYYY-MM-DD';
+    this.showClear = obj && obj.showClear ? obj.showClear : false;
+    this.isReadOnly = obj && obj.isReadOnly ? obj.isReadOnly : false;
   }
 }
 
@@ -370,6 +376,18 @@ export class DatePickerComponent implements ControlValueAccessor, OnInit {
 
   openYearPicker() {
     setTimeout(() => this.yearPicker = true);
+  }
+
+  clear(){
+    this.date = new DateModel({
+      day: null,
+      month: null,
+      year: null,
+      formatted: null,
+      momentObj: null
+    });
+
+    this.value = this.date;    
   }
 
 }


### PR DESCRIPTION
Add isReadOnly: true to options to make the text input readonly. 
Add showClear:true to options to display a button to clear the date field (only shows when the date field is not empty).