### PR TITLE
setting moduleId on datepicker component - 

### DIFF
--- a/src/ng2-datepicker/ng2-datepicker.component.ts
+++ b/src/ng2-datepicker/ng2-datepicker.component.ts
@@ -80,6 +80,7 @@ export const CALENDAR_VALUE_ACCESSOR: any = {
 
 
 @Component({
+  moduleId: module.id,
   selector: 'ng2-datepicker',
   templateUrl: './ng2-datepicker.component.html',
   styleUrls: ['./ng2-datepicker.css'],


### PR DESCRIPTION
allows for module-relative loading of template/css urls

see issue #183 