### PR TITLE
fix height for 6 week months

### DIFF
--- a/src/ng-datepicker/ng-datepicker.component.sass
+++ b/src/ng-datepicker/ng-datepicker.component.sass
@@ -71,7 +71,7 @@ $color: #1A91EB
         padding: 15px 0
         width: 100%
         display: inline-block
-        max-height: 225px
+        max-height: 275px
         overflow: hidden
 
         .day-unit, .year-unit


### PR DESCRIPTION
As per [6th week not showing on ng-datepicker](https://github.com/jkuri/ng2-datepicker/issues/267)
The max-height should be bigger